### PR TITLE
feat: Add SQT5font option for b&w

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -67,6 +67,12 @@
           "values": [
             "US"
           ]
+        },
+        "sqt5font": {
+          "build_flag": "FONT",
+          "values": [
+            "SQT5"
+          ]
         }
       }
     },


### PR DESCRIPTION
Adds the `FONT=SQT5` font option for b&w / stdlcd radios. Since the only other option is the default `STD`,  I think it is better to have the flag just for sqt5font. 