### PR TITLE
chore: add `HE`, `UA`, update action versions, add json validation

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -39,13 +39,13 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ^1.20.0
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint
         run: make lint
@@ -58,32 +58,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         run: npm install --prefix ui/
       - name: Lint
         run: npm run lint --prefix ui/
-        
+
   build:
     runs-on: ubuntu-latest
     needs: [ test-backend, test-frontend ]
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             name=ghcr.io/edgetx/cloudbuild
@@ -94,14 +94,14 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push cloudbuild
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ./Dockerfile.production

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -15,6 +15,17 @@ on:
       - '**.md'
 
 jobs:
+  json-validate:
+      name: Validate JSON/YML files
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: json-yaml-validate
+          uses: GrantBirki/json-yaml-validate@v2
+          with:
+            mode: fail
+
   test-backend:
     name: Test backend
     runs-on: ubuntu-22.04

--- a/targets.json
+++ b/targets.json
@@ -49,14 +49,15 @@
         "ES",
         "FI",
         "FR",
+        "HU",
         "IT",
         "PT",
         "RU",
         "SK",
         "SE",
         "PL",
-        "HU",
-        "NL"
+        "NL",
+        "UA"
       ]
     },
     "fai_mode": {
@@ -73,6 +74,7 @@
         "language": {
           "values": [
             "CN",
+            "HE",
             "JP",
             "TW"
           ]

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,32 +1,44 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-
-    /* path alias */
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"],
-      "@hooks/*": ["./src/hooks/*"],
-      "@pages/*": ["./src/pages/*"],
-      "@comps/*": ["./src/components/*"]
-    }
-  },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+    "compilerOptions": {
+        "target": "ESNext",
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ESNext"
+        ],
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "baseUrl": ".",
+        "paths": {
+            "@/*": [
+                "./src/*"
+            ],
+            "@hooks/*": [
+                "./src/hooks/*"
+            ],
+            "@pages/*": [
+                "./src/pages/*"
+            ],
+            "@comps/*": [
+                "./src/components/*"
+            ]
+        }
+    },
+    "include": [
+        "src"
+    ],
+    "references": [
+        {
+            "path": "./tsconfig.node.json"
+        }
+    ]
 }


### PR DESCRIPTION
HE - Hebrew is only supported on colorlcd atm
UA - Ukrainian is colorlcd focused, but may partially work on B&W 

Note: UA is supported from 2.10 onwards (as is RU, incidentally), so it is normal and **expected** that if anyone tries to build earlier firmwares with either of those translation flags that the build **will** fail. 

While I was here, might as well update all the actions as necessary due to the NodeJS 16 depreciation... there is now a (strictly informational) warning regarding go action caching now, but that may go away after this is merged or on the next full proper run, as I don't think it has had a chance to build it's cache yet (but `go.sum` file appears to be present)... https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs

Also, add a JSON (and as a bonus YML) validation step that will fail the PR checks if any of the JSON or YML files are invalid (as it appears `ui/tsconfig.json` was as comments are explicitly **not** valid in JSON). 

Will merge in 24 hours unless instructed otherwise (or I forget :laughing: )