### PR TITLE
chore: use official golang-lint action

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -58,8 +58,10 @@ jobs:
           go-version: ^1.20.0
         id: go
 
-      - name: Lint
-        run: make lint
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
 
       - name: Test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
   timeout: 5m
-  debug: true
 
 linters-settings:
   gocritic:
@@ -57,3 +56,5 @@ linters:
     - goprintffuncname
     - whitespace
     - thelper
+  disabe:
+    - goanalysis_metalinter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters-settings:
     disabled-checks:
       - exitAfterDefer
   gofumpt:
-    lang-version: "1.23"
+    lang-version: "1.18"
 
 output:
   format: colored-line-number
@@ -56,5 +56,3 @@ linters:
     - goprintffuncname
     - whitespace
     - thelper
-  disable:
-    - goanalysis_metalinter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters-settings:
     disabled-checks:
       - exitAfterDefer
   gofumpt:
-    lang-version: "1.18"
+    lang-version: "1.23"
 
 output:
   format: colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,5 +56,5 @@ linters:
     - goprintffuncname
     - whitespace
     - thelper
-  disabe:
+  disable:
     - goanalysis_metalinter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   timeout: 5m
+  debug: true
 
 linters-settings:
   gocritic:


### PR DESCRIPTION
looks like the self-build isn't working properly. This is supposed to integrate better anyway, and give inline errors, and since it caches, should be faster.