### PR TITLE
feat: add power led blue flag to cloud build

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -159,6 +159,10 @@
     "disable_mcucheck": {
       "build_flag": "DISABLE_MCUCHECK",
       "values": ["YES", "NO"]
+    },
+    "power_led_blue": {
+      "build_flag": "POWER_LED_BLUE",
+      "values": ["YES", "NO"]
     }
   },
   "tags": {


### PR DESCRIPTION
Adds POWER_LED_BLUE to Flags since it was recently added in February and a decent amount of people seem to be interested (me included) according to https://github.com/EdgeTX/edgetx/issues/5010