### PR TITLE
feat: added build job search by commit hash

### DIFF
--- a/artifactory/build_jobs_repository.go
+++ b/artifactory/build_jobs_repository.go
@@ -118,6 +118,14 @@ func jobQueryClause(query *JobQuery) func(db *gorm.DB) *gorm.DB {
 			refs := strings.Split(query.Release, ",")
 			db = db.Where("commit_ref IN(?)", refs)
 		}
+		if query.Sha != "" {
+			shas := strings.Split(query.Sha, ",")
+			db = db.Where("commit_hash IN(?)", shas)
+		}
+		if query.NotSha != "" {
+			shas := strings.Split(query.NotSha, ",")
+			db = db.Where("commit_hash NOT IN(?)", shas)
+		}
 		return db
 	}
 }

--- a/artifactory/job_query.go
+++ b/artifactory/job_query.go
@@ -9,6 +9,8 @@ type JobQuery struct {
 	Status  string `form:"status"`
 	Release string `form:"release"`
 	Target  string `form:"target"`
+	Sha     string `form:"sha"`
+	NotSha  string `form:"not-sha"`
 }
 
 func (q *JobQuery) Validate() error {


### PR DESCRIPTION
That should allow to produce some scripts to clean obsolete builds (yesterday's `nightly` for instance).