### PR TITLE
chore: add 2.11.2 release, alphabetize targets

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -6,15 +6,20 @@
         "path": "object.sha"
       }
     },
+    "v2.11.2": {
+      "sha": "84cde07404cc6ee664f8f59aea604fe02c708d5d",
+      "build_container": "ghcr.io/edgetx/edgetx-builder:2.11",
+      "exclude_targets": ["x10-access", "x7-access"]
+    },
     "v2.11.1": {
       "sha": "dfc8aa545796d1d437d4ee1e57a6dbfb87f754fc",
       "build_container": "ghcr.io/edgetx/edgetx-builder:2.11",
-      "exclude_targets": ["x10-access", "x7-access"]
+      "exclude_targets": ["x10-access", "x7-access", "pl18u"]
     },
     "v2.11.0": {
       "sha": "8369a2e23a7253a9ea4c9a8cb7c80e5fcf23d235",
       "build_container": "ghcr.io/edgetx/edgetx-builder:2.11",
-      "exclude_targets": ["x10-access", "x7-access"]
+      "exclude_targets": ["x10-access", "x7-access", "pl18u"]
     },
     "v2.10.6": {
       "sha": "14adf0474ccedbd935fac7d71958946680b5fdfc",
@@ -27,7 +32,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.10.5": {
@@ -41,7 +47,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.10.4": {
@@ -56,7 +63,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.10.3": {
@@ -71,7 +79,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.10.2": {
@@ -88,7 +97,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.10.1": {
@@ -106,7 +116,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.10.0": {
@@ -125,7 +136,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.9.4": {
@@ -152,7 +164,8 @@
         "st16",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     },
     "v2.8.5": {
@@ -178,7 +191,8 @@
         "x7access",
         "v12",
         "v14",
-        "v16"
+        "v16",
+        "pl18u"
       ]
     }
   },
@@ -286,6 +300,10 @@
     },
     "pl18ev": {
       "description": "Flysky PL18EV",
+      "tags": ["colorlcd"]
+    },
+    "pl18u": {
+      "description": "Flysky PL18U",
       "tags": ["colorlcd"]
     },
     "st16": {

--- a/targets.json
+++ b/targets.json
@@ -286,12 +286,12 @@
       "description": "Flysky EL18",
       "tags": ["colorlcd"]
     },
-    "nv14": {
-      "description": "Flysky NV14",
-      "tags": ["colorlcd"]
-    },
     "nb4p": {
       "description": "Flysky NB4+",
+      "tags": ["colorlcd"]
+    },
+    "nv14": {
+      "description": "Flysky NV14",
       "tags": ["colorlcd"]
     },
     "pl18": {
@@ -308,22 +308,6 @@
     },
     "st16": {
       "description": "Flysky ST16",
-      "tags": ["colorlcd"]
-    },
-    "x10": {
-      "description": "FrSky Horus X10",
-      "tags": ["colorlcd"]
-    },
-    "x10-access": {
-      "description": "FrSky Horus X10 Access",
-      "tags": ["colorlcd"]
-    },
-    "x10express": {
-      "description": "FrSky Horus X10 Express",
-      "tags": ["colorlcd"]
-    },
-    "x12s": {
-      "description": "FrSky Horus X12S",
       "tags": ["colorlcd"]
     },
     "x7": {
@@ -362,16 +346,28 @@
       "description": "FrSky X9 Lite S",
       "tags": ["stdlcd"]
     },
+    "x10": {
+      "description": "FrSky Horus X10",
+      "tags": ["colorlcd"]
+    },
+    "x10-access": {
+      "description": "FrSky Horus X10 Access",
+      "tags": ["colorlcd"]
+    },
+    "x10express": {
+      "description": "FrSky Horus X10 Express",
+      "tags": ["colorlcd"]
+    },
+    "x12s": {
+      "description": "FrSky Horus X12S",
+      "tags": ["colorlcd"]
+    },
     "xlite": {
       "description": "FrSky X-Lite",
       "tags": ["stdlcd"]
     },
     "xlites": {
       "description": "FrSky X-Lite S",
-      "tags": ["stdlcd"]
-    },
-    "commando8": {
-      "description": "iFlight Commando 8",
       "tags": ["stdlcd"]
     },
     "v12": {
@@ -385,6 +381,10 @@
     "v16": {
       "description": "HelloRadioSky V16",
       "tags": ["colorlcd", "bluetooth"]
+    },
+    "commando8": {
+      "description": "iFlight Commando 8",
+      "tags": ["stdlcd"]
     },
     "bumblebee": {
       "description": "Jumper Bumblebee",


### PR DESCRIPTION
Adds the 2.11.2 release and ensures all targets are properly alphabetized within their manufacturer groups, as well as the manufacturer groups themselves.